### PR TITLE
Run renovate from docker

### DIFF
--- a/cloudformation/renovate.yml
+++ b/cloudformation/renovate.yml
@@ -150,6 +150,10 @@ Resources:
                     - /renovate-aws/platform_token
                 - "\n"
             - |
+                Cache:
+                  Type: LOCAL
+                  Modes: 
+                    - LOCAL_DOCKER_LAYER_CACHE
                 phases:
                   install:
                     runtime-versions:

--- a/cloudformation/renovate.yml
+++ b/cloudformation/renovate.yml
@@ -29,11 +29,7 @@ Parameters:
     AllowedValues:
       - github
       - gitlab
-
-  RenovatePlatformToken:
-    Type: String
-    MinLength: 1
-    NoEcho: true
+      - bitbucket
 
   Image:
     Type: String
@@ -50,20 +46,7 @@ Parameters:
 Conditions:
   HasRenovateSchedule: {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "RenovateSchedule"}]}]}
 
-Mappings:
-  PlatformToEnv:
-    gitlab:
-      Value: "    GITLAB_TOKEN"
-    github:
-      Value: "    GITHUB_TOKEN"
-
 Resources:
-  RenovatePlatformTokenParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: /renovate-aws/platform_token
-      Value: !Ref RenovatePlatformToken
 
   RenovateRole:
     Type: AWS::IAM::Role
@@ -162,7 +145,7 @@ Resources:
                 - !Join
                   - ": "
                   -
-                    - !FindInMap [ PlatformToEnv, !Ref "RenovatePlatform", Value ]
+                    - "    RENOVATE_TOKEN"
                     - /renovate-aws/platform_token
                 - "\n"
             - |

--- a/cloudformation/renovate.yml
+++ b/cloudformation/renovate.yml
@@ -33,7 +33,7 @@ Parameters:
 
   Image:
     Type: String
-    Default: aws/codebuild/nodejs:10.1.0
+    Default: aws/codebuild/standard:2.0
 
   ComputerType:
     Type: String
@@ -41,7 +41,7 @@ Parameters:
 
   TimeoutInMinutes:
     Type: Number
-    Default: 10
+    Default: 20
 
 Conditions:
   HasRenovateSchedule: {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "RenovateSchedule"}]}]}
@@ -119,6 +119,7 @@ Resources:
         ComputeType: !Ref ComputerType
         Image: !Ref Image
         Type: LINUX_CONTAINER
+        PrivilegedMode: true
         EnvironmentVariables:
           - Name: RENOVATE_VERSION
             Value: !Ref RenovateVersion
@@ -151,12 +152,15 @@ Resources:
             - |
                 phases:
                   install:
+                    runtime-versions:
+                      docker: 18
                     commands:
-                      - npm install renovate@${RENOVATE_VERSION}
-                      - "$(npm bin)/renovate --version"
+                      - docker pull renovate/renovate:${RENOVATE_VERSION}
+                      - env > host.env
                   build:
                     commands:
-                      - $(npm bin)/renovate ${RENOVATE_FLAGS}
+                      - docker run --env-file ./host.env renovate/renovate:${RENOVATE_VERSION}
+
       TimeoutInMinutes: !Ref TimeoutInMinutes
 
 Outputs:


### PR DESCRIPTION
The node version has been failing with error

```
    node_modules/renovate/dist/versioning/index.js:18
        .filter(dirent => dirent.isDirectory() &&
        !dirent.name.startsWith('_'))

    TypeError: dirent.isDirectory is not a function
       at fs_1.default.readdirSync.filter.dirent (/codebuild/output/src091269395/src/node_modules/renovate/dist/versioning/index.js:18:30)
    at Array.filter (<anonymous>)
    at Object.<anonymous> (/codebuild/output/src091269395/src/node_modules/renovate/dist/versioning/index.js:18:6)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)
    at Module.load (internal/modules/cjs/loader.js:589:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:528:12)
    at Function.Module._load (internal/modules/cjs/loader.js:520:3)
    at Module.require (internal/modules/cjs/loader.js:626:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/codebuild/output/src091269395/src/node_modules/renovate/dist/config/definitions.js:13:22)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)
    at Module.load (internal/modules/cjs/loader.js:589:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:528:12)
    at Function.Module._load (internal/modules/cjs/loader.js:520:3)
    at Module.require (internal/modules/cjs/loader.js:626:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/codebuild/output/src091269395/src/node_modules/renovate/dist/config/index.js:14:34)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
```

Update the cloudformation template to run renovate using docker